### PR TITLE
Add global strictMode config var

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,9 +41,7 @@ const loggerLevelFlag = "verbosity"
 const addressFlag = "address"
 const defaultLogLevel = "info"
 const defaultAddress = "localhost:1323"
-const defaultEnvironment = "development"
-const environmentFlag = "environment"
-const productionEnvironment = "production"
+const strictModeFlag = "strictmode"
 
 var defaultIgnoredPrefixes = []string{"root"}
 
@@ -93,9 +91,9 @@ func (ngc *NutsGlobalConfig) ServerAddress() string {
 	return ngc.v.GetString(addressFlag)
 }
 
-// IsProductionMode helps to safeguard settings which are handy and default in development but not safe for production.
-func (ngc *NutsGlobalConfig) IsProductionMode() bool {
-	return ngc.v.GetString(environmentFlag) == productionEnvironment
+// InStrictMode helps to safeguard settings which are handy and default in development but not safe for production.
+func (ngc *NutsGlobalConfig) InStrictMode() bool {
+	return ngc.v.GetBool(strictModeFlag)
 }
 
 // Load sets some initial config in order to be able for commands to load the right parameters and to add the configFile Flag.
@@ -108,7 +106,7 @@ func (ngc *NutsGlobalConfig) Load(cmd *cobra.Command) error {
 	flagSet.String(configFileFlag, ngc.DefaultConfigFile, "Nuts config file")
 	flagSet.String(loggerLevelFlag, defaultLogLevel, "Log level")
 	flagSet.String(addressFlag, defaultAddress, "Address and port the server will be listening to")
-	flagSet.String(environmentFlag, defaultEnvironment, "Environment to run the node in.")
+	flagSet.Bool(strictModeFlag, false, "When set, insecure settings are forbidden.")
 	cmd.PersistentFlags().AddFlagSet(flagSet)
 
 	// Bind config flag
@@ -116,7 +114,7 @@ func (ngc *NutsGlobalConfig) Load(cmd *cobra.Command) error {
 	ngc.bindFlag(flagSet, configFileFlag)
 	ngc.bindFlag(flagSet, loggerLevelFlag)
 	ngc.bindFlag(flagSet, addressFlag)
-	ngc.bindFlag(flagSet, environmentFlag)
+	ngc.bindFlag(flagSet, strictModeFlag)
 
 	// load flags into viper
 	pfs := cmd.PersistentFlags()
@@ -130,11 +128,6 @@ func (ngc *NutsGlobalConfig) Load(cmd *cobra.Command) error {
 	// load configFile into viper
 	if err := ngc.loadConfigFile(); err != nil {
 		return err
-	}
-
-	// validate environment flag
-	if env := ngc.v.GetString(environmentFlag); env != "development" && env != "production" {
-		return fmt.Errorf("invalid value for environment flag: %s. Allowed values: [production, development]", env)
 	}
 
 	// initialize logger, verbosity flag needs to be available
@@ -190,7 +183,7 @@ func (ngc *NutsGlobalConfig) PrintConfig(logger log.FieldLogger) {
 	logger.Infof(f, addressFlag, ngc.v.Get(addressFlag))
 	logger.Infof(f, configFileFlag, ngc.v.Get(configFileFlag))
 	logger.Infof(f, loggerLevelFlag, ngc.v.Get(loggerLevelFlag))
-	logger.Infof(f, environmentFlag, ngc.v.Get(environmentFlag))
+	logger.Infof(f, strictModeFlag, ngc.v.Get(strictModeFlag))
 	for _, e := range EngineCtl.Engines {
 		if e.FlagSet != nil {
 			e.FlagSet.VisitAll(func(flag *pflag.Flag) {
@@ -293,7 +286,7 @@ func (ngc *NutsGlobalConfig) injectIntoStruct(s interface{}) error {
 
 	for _, configName := range ngc.v.AllKeys() {
 		// ignore configFile flag
-		if configName == configFileFlag || configName == loggerLevelFlag || configName == addressFlag || configName == environmentFlag {
+		if configName == configFileFlag || configName == loggerLevelFlag || configName == addressFlag || configName == strictModeFlag {
 			continue
 		}
 

--- a/config.go
+++ b/config.go
@@ -184,6 +184,7 @@ func (ngc *NutsGlobalConfig) PrintConfig(logger log.FieldLogger) {
 	logger.Infof(f, addressFlag, ngc.v.Get(addressFlag))
 	logger.Infof(f, configFileFlag, ngc.v.Get(configFileFlag))
 	logger.Infof(f, loggerLevelFlag, ngc.v.Get(loggerLevelFlag))
+	logger.Infof(f, environmentFlag, ngc.v.Get(environmentFlag))
 	for _, e := range EngineCtl.Engines {
 		if e.FlagSet != nil {
 			e.FlagSet.VisitAll(func(flag *pflag.Flag) {

--- a/config.go
+++ b/config.go
@@ -41,6 +41,8 @@ const loggerLevelFlag = "verbosity"
 const addressFlag = "address"
 const defaultLogLevel = "info"
 const defaultAddress = "localhost:1323"
+const defaultEnvironment = "development"
+const environmentFlag = "environment"
 
 var defaultIgnoredPrefixes = []string{"root"}
 
@@ -100,6 +102,7 @@ func (ngc *NutsGlobalConfig) Load(cmd *cobra.Command) error {
 	flagSet.String(configFileFlag, ngc.DefaultConfigFile, "Nuts config file")
 	flagSet.String(loggerLevelFlag, defaultLogLevel, "Log level")
 	flagSet.String(addressFlag, defaultAddress, "Address and port the server will be listening to")
+	flagSet.String(environmentFlag, defaultEnvironment, "Environment to run the node in.")
 	cmd.PersistentFlags().AddFlagSet(flagSet)
 
 	// Bind config flag
@@ -107,6 +110,7 @@ func (ngc *NutsGlobalConfig) Load(cmd *cobra.Command) error {
 	ngc.bindFlag(flagSet, configFileFlag)
 	ngc.bindFlag(flagSet, loggerLevelFlag)
 	ngc.bindFlag(flagSet, addressFlag)
+	ngc.bindFlag(flagSet, environmentFlag)
 
 	// load flags into viper
 	pfs := cmd.PersistentFlags()
@@ -120,6 +124,11 @@ func (ngc *NutsGlobalConfig) Load(cmd *cobra.Command) error {
 	// load configFile into viper
 	if err := ngc.loadConfigFile(); err != nil {
 		return err
+	}
+
+	// validate environment flag
+	if env := ngc.v.GetString(environmentFlag); env != "development" && env != "production" {
+		return fmt.Errorf("invalid value for environment flag: %s. Allowed values: [production, development]", env)
 	}
 
 	// initialize logger, verbosity flag needs to be available
@@ -277,7 +286,7 @@ func (ngc *NutsGlobalConfig) injectIntoStruct(s interface{}) error {
 
 	for _, configName := range ngc.v.AllKeys() {
 		// ignore configFile flag
-		if configName == configFileFlag || configName == loggerLevelFlag || configName == addressFlag {
+		if configName == configFileFlag || configName == loggerLevelFlag || configName == addressFlag || configName == environmentFlag {
 			continue
 		}
 

--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ const defaultLogLevel = "info"
 const defaultAddress = "localhost:1323"
 const defaultEnvironment = "development"
 const environmentFlag = "environment"
+const productionEnvironment = "production"
 
 var defaultIgnoredPrefixes = []string{"root"}
 
@@ -90,6 +91,11 @@ func NutsConfig() *NutsGlobalConfig {
 
 func (ngc *NutsGlobalConfig) ServerAddress() string {
 	return ngc.v.GetString(addressFlag)
+}
+
+// IsProductionMode helps to safeguard settings which are handy and default in development but not safe for production.
+func (ngc *NutsGlobalConfig) IsProductionMode() bool {
+	return ngc.v.GetString(environmentFlag) == productionEnvironment
 }
 
 // Load sets some initial config in order to be able for commands to load the right parameters and to add the configFile Flag.

--- a/config_test.go
+++ b/config_test.go
@@ -141,15 +141,20 @@ func TestNutsGlobalConfig_Load2(t *testing.T) {
 		}
 	})
 
-	t.Run("Returns error for incorrect environment", func(t *testing.T) {
-		os.Args = []string{"command", "--environment", "staging"}
+	t.Run("Strict-mode is off by default", func(t *testing.T) {
+		os.Args = []string{"command"}
 		cfg := NewNutsGlobalConfig()
-
 		err := cfg.Load(&cobra.Command{})
+		assert.NoError(t, err)
+		assert.False(t, cfg.InStrictMode())
+	})
 
-		assert.Error(t, err)
-		expected := "invalid value for environment flag: staging. Allowed values: [production, development]"
-		assert.EqualError(t, err, expected)
+	t.Run("Strict-mode can be turned on", func(t *testing.T) {
+		os.Args = []string{"command", "--strictmode"}
+		cfg := NewNutsGlobalConfig()
+		err := cfg.Load(&cobra.Command{})
+		assert.NoError(t, err)
+		assert.True(t, cfg.InStrictMode())
 	})
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"reflect"
 	"strings"
@@ -138,6 +139,17 @@ func TestNutsGlobalConfig_Load2(t *testing.T) {
 		if err.Error() != expected {
 			t.Errorf("Expected error [%s], got [%v]", expected, err)
 		}
+	})
+
+	t.Run("Returns error for incorrect environment", func(t *testing.T) {
+		os.Args = []string{"command", "--environment", "staging"}
+		cfg := NewNutsGlobalConfig()
+
+		err := cfg.Load(&cobra.Command{})
+
+		assert.Error(t, err)
+		expected := "invalid value for environment flag: staging. Allowed values: [production, development]"
+		assert.EqualError(t, err, expected)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
+	github.com/stretchr/testify v1.4.0
 	github.com/valyala/fasttemplate v1.1.0 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20191011234655-491137f69257 // indirect


### PR DESCRIPTION
~~Can be used to put the node in "development" or "production" mode.~~
Adds a strictMode boolean flag and an getter on `core.NutsConfig().InStrictMode()`. This var can be used by modules to check if config variables and combinations are valid. Like: do not accept IRMA demo attributes when strict mode is on.