### PR TITLE
Fix DecodeURIPath after updating echo

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -82,8 +82,7 @@ type Engine struct {
 func DecodeURIPath(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// FIXME: This is a hack because of https://github.com/labstack/echo/issues/1258
-		// Create a list with enough space for 10 path params
-		newValues := make([]string, 10)
+		newValues := make([]string, len(c.ParamValues()))
 		for i, value := range c.ParamValues() {
 			path, err := url.PathUnescape(value)
 			if err != nil {


### PR DESCRIPTION
SetParamValues now preserves the original array instead of replacing it. We can no longer just use a large number. Since `len(c.ParamValues) <= c.masParams` this should fix it.

reference to issue https://github.com/labstack/echo/issues/1258