### PR TITLE
Fix use of incorrect const in GetEngineMode()

### DIFF
--- a/config.go
+++ b/config.go
@@ -128,7 +128,7 @@ func (ngc NutsGlobalConfig) GetEngineMode(engineMode string) string {
 		case GlobalCLIMode:
 			return ClientEngineMode
 		default:
-			return GlobalServerMode
+			return ServerEngineMode
 		}
 	}
 	return engineMode


### PR DESCRIPTION
Constant values are the same though, so the fix is for semantics.