### PR TITLE
Added mandatory 'identity' configuration parameter

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -23,4 +23,7 @@ package core
 const NutsOID = "1.3.6.1.4.1.54851"
 
 // NutsConsentClassesOID is the sub-OID used for consent classification
-const NutsConsentClassesOID = "1.3.6.1.4.1.54851.1"
+const NutsConsentClassesOID = NutsOID + ".1"
+
+// NutsVendorOID is the sub-OID used for vendor identifiers
+const NutsVendorOID = NutsOID + ".4"


### PR DESCRIPTION
Is required for https://github.com/nuts-foundation/nuts-registry/issues/43

After merging, NUTS_IDENTITY (or identity in nuts.yaml) **must** be provided as a URN-encoded vendor ID.